### PR TITLE
Support LayoutSpec Buildable

### DIFF
--- a/TextureSwiftSupport.xcodeproj/project.pbxproj
+++ b/TextureSwiftSupport.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		4BC70ECB23F74EAB00197B7B /* SafeAreaDisplayNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC70ECA23F74EAB00197B7B /* SafeAreaDisplayNode.swift */; };
 		4BC70ECD23F7557E00197B7B /* NamedDisplayCellNodeBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC70ECC23F7557E00197B7B /* NamedDisplayCellNodeBase.swift */; };
 		99A18E1BF9C46EC619085416 /* Pods_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DEDB4E127B7A4C426A1B216 /* Pods_Demo.framework */; };
+		DA9633E623FCB9530008C71D /* LayoutSpecBuildable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9633E523FCB9530008C71D /* LayoutSpecBuildable.swift */; };
 		F3E933F1BC6075B11F4E033B /* Pods_TextureSwiftSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4403C6E378DD73AD896F3CF1 /* Pods_TextureSwiftSupport.framework */; };
 /* End PBXBuildFile section */
 
@@ -75,6 +76,7 @@
 		4BC70ECC23F7557E00197B7B /* NamedDisplayCellNodeBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedDisplayCellNodeBase.swift; sourceTree = "<group>"; };
 		5DEDB4E127B7A4C426A1B216 /* Pods_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8727E50E77B25BA7D77A0D27 /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		DA9633E523FCB9530008C71D /* LayoutSpecBuildable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutSpecBuildable.swift; sourceTree = "<group>"; };
 		E3C240A10D90D0F926A2A7EF /* Pods-TextureSwiftSupport.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TextureSwiftSupport.release.xcconfig"; path = "Target Support Files/Pods-TextureSwiftSupport/Pods-TextureSwiftSupport.release.xcconfig"; sourceTree = "<group>"; };
 		E71FEF2D53270242B012F34A /* Pods-TextureSwiftSupport.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TextureSwiftSupport.debug.xcconfig"; path = "Target Support Files/Pods-TextureSwiftSupport/Pods-TextureSwiftSupport.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -162,6 +164,7 @@
 			children = (
 				4B873C2D23083FF4006170B1 /* SpecBuilder.swift */,
 				4B8A3025234DF6AD00082092 /* MethodChain.swift */,
+				DA9633E523FCB9530008C71D /* LayoutSpecBuildable.swift */,
 			);
 			path = SpecBuilder;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B8A3026234DF6AD00082092 /* MethodChain.swift in Sources */,
+				DA9633E623FCB9530008C71D /* LayoutSpecBuildable.swift in Sources */,
 				4BC70EC923F74E8C00197B7B /* NamedDisplayNodeBase.swift in Sources */,
 				4BC70EC723F74D3A00197B7B /* DisplayNodeViewController.swift in Sources */,
 				4B5CEFC8235264CA00607980 /* _NodeLayout.swift in Sources */,

--- a/TextureSwiftSupport/SpecBuilder/LayoutSpecBuildable.swift
+++ b/TextureSwiftSupport/SpecBuilder/LayoutSpecBuildable.swift
@@ -1,0 +1,60 @@
+//
+//  LayoutSpecBuildable.swift
+//  TextureSwiftSupport
+//
+//  Created by Geektree0101 on 19/02/2020.
+//  Copyright © 2020 muukii. All rights reserved.
+//
+
+import Foundation
+import AsyncDisplayKit
+
+public enum LayoutSpecBuildableOptions {
+  
+  case safeArea
+  case layoutMargins
+}
+
+public protocol LayoutSpecBuildable {
+  
+  var layoutSpec: ASLayoutSpec { get }
+}
+
+private var layoutSpecBuildableConstrainedSizeKey: String = "LayoutSpecBuildable.constrainedSize"
+
+extension LayoutSpecBuildable where Self: ASDisplayNode {
+  
+  public var constraintedSize: ASSizeRange {
+    get {
+      return (objc_getAssociatedObject(
+        self,
+        &layoutSpecBuildableConstrainedSizeKey
+        ) as? ASSizeRange) ?? ASSizeRangeUnconstrained
+    }
+    set {
+      objc_setAssociatedObject(
+        self,
+        &layoutSpecBuildableConstrainedSizeKey,
+        newValue,
+        .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+      )
+    }
+  }
+  
+  public func automaticallyManagesLayoutSpecBuilder(changeSet: LayoutSpecBuildableOptions...) {
+    
+    self.automaticallyRelayoutOnSafeAreaChanges = changeSet.contains(.safeArea)
+    self.automaticallyRelayoutOnLayoutMarginsChanges = changeSet.contains(.layoutMargins)
+    self.automaticallyManagesLayoutSpecBuilder()
+  }
+  
+  
+  public func automaticallyManagesLayoutSpecBuilder() {
+    
+    self.automaticallyManagesSubnodes = true
+    self.layoutSpecBlock = { [weak self] (_, sizeRange) -> ASLayoutSpec in
+      self?.constraintedSize = sizeRange
+      return self?.layoutSpec ?? ASLayoutSpec()
+    }
+  }
+}


### PR DESCRIPTION
Inspired by SwiftUI `body` property

- Can access updated constraintedSize property
- Don't needs override layoutSpecThatFits: method

> Example
```swift
import AsyncDisplayKit
import TextureSwiftSupport

class CardNode: ASDisplayNode, LayoutSpecBuildable {
  
  // MARK: - UI Components
  
  let thumnailImageNode: ASNetworkImageNode = ...
  let titleNode: ASTextNode = ...
  let contentNode: ASTextNode = ...
  let userNode: UserProfileNode = ...
  let curationBadgeNode: CurationBadgeNode = ...
  
  override init() {
    super.init()
    self.automaticallyManagesLayoutSpecBuilder()
  }
  
  // MARK: - LayoutSpec
  
  var layoutSpec: ASLayoutSpec {
    LayoutSpec {
      VStackLayout {
        mediaAreaLayoutSpec
        VSpacerLayout(minLength: 2.0)
        titleNode.flexShrink(1.0)
        VSpacerLayout(minLength: 4.0)
        contentNode.flexShrink(1.0)
        VSpacerLayout(minLength: 4.0)
        userNode
      }
    }
  }
  
  var mediaAreaLayoutSpec: ASLayoutSpec {
    LayoutSpec {
      AspectRatioLayout(ratio: 1.0) {
        thumnailImageNode
      }.overlay(
        RelativeLayout(
          horizontalPosition: .end,
          verticalPosition: .start
        ) {
          curationBadgeNode
        }
      )
    }
  }
}
```