### PR TITLE
Allow spec builders in overlay() and background()

### DIFF
--- a/Sources/LayoutSpecBuilders/Layout/BackgroundLayout.swift
+++ b/Sources/LayoutSpecBuilders/Layout/BackgroundLayout.swift
@@ -13,7 +13,10 @@ public struct BackgroundLayout<BackgroundContnt, Content> : _ASLayoutElementType
 
   public func tss_make() -> [ASLayoutElement] {
     [
-      ASBackgroundLayoutSpec(child: content.tss_make().first!, background: background.tss_make().first!)
+      ASBackgroundLayoutSpec(
+        child: content.tss_make().first!,
+        background: background.tss_make().first ?? ASLayoutSpec()
+      )
     ]
   }
 

--- a/Sources/LayoutSpecBuilders/Layout/OverlayLayout.swift
+++ b/Sources/LayoutSpecBuilders/Layout/OverlayLayout.swift
@@ -12,7 +12,10 @@ public struct OverlayLayout<OverlayContnt, Content> : _ASLayoutElementType where
 
   public func tss_make() -> [ASLayoutElement] {
     [
-      ASOverlayLayoutSpec(child: content.tss_make().first!, overlay: overlay.tss_make().first!)
+      ASOverlayLayoutSpec(
+        child: content.tss_make().first!,
+        overlay: overlay.tss_make().first ?? ASLayoutSpec()
+      )
     ]
   }
 

--- a/Sources/LayoutSpecBuilders/Modifiers.swift
+++ b/Sources/LayoutSpecBuilders/Modifiers.swift
@@ -138,9 +138,17 @@ extension _ASLayoutElementType {
   public func background<Background: _ASLayoutElementType>(_ backgroundContent: Background) -> BackgroundLayout<Background, Self> {
     BackgroundLayout(content: { self }, background: { backgroundContent })
   }
+
+  public func background<Background: _ASLayoutElementType>(@ASLayoutSpecBuilder _ backgroundContent: () -> Background) -> BackgroundLayout<Background, Self> {
+    BackgroundLayout(content: { self }, background: backgroundContent)
+  }
     
   public func overlay<Overlay: _ASLayoutElementType>(_ overlayContent: Overlay) -> OverlayLayout<Overlay, Self> {
     OverlayLayout(content: { self }, overlay: { overlayContent })
+  }
+
+  public func overlay<Overlay: _ASLayoutElementType>(@ASLayoutSpecBuilder _ overlayContent: () -> Overlay) -> OverlayLayout<Overlay, Self> {
+    OverlayLayout(content: { self }, overlay: overlayContent)
   }
   
   /// Make aspectRatio


### PR DESCRIPTION
Addresses two issues:
1. There is currently no way to have optional/conditional overlays and backgrounds
2. `OverlayLayout` and `BackgroundLayout` both crashes if the overlay/background have empty elements (ex: `EmptyLayout`) which makes it difficult to create workarounds for (1.)