### PR TITLE
Add width & height function with ASDimension parameter

### DIFF
--- a/Sources/LayoutSpecBuilders/Modifiers.swift
+++ b/Sources/LayoutSpecBuilders/Modifiers.swift
@@ -377,8 +377,16 @@ extension _ASLayoutElementType {
     modifier(SizeModifier(width: .init(unit: .points, value: width), height: nil))
   }
   
+  public func width(_ width: ASDimension) -> ModifiedContent<Self, SizeModifier> {
+    modifier(SizeModifier(width: width, height: nil))
+  }
+  
   public func height(_ height: CGFloat) -> ModifiedContent<Self, SizeModifier> {
     modifier(SizeModifier(width: nil, height: .init(unit: .points, value: height)))
+  }
+  
+  public func height(_ height: ASDimension) -> ModifiedContent<Self, SizeModifier> {
+    modifier(SizeModifier(width: nil, height: height))
   }
     
   public func minSize(_ size: CGSize) -> ModifiedContent<Self, MinSizeModifier> {


### PR DESCRIPTION
## What
Adding width & height specifier that accepts `ASDimension` as parameter

## Background
Currently, TextureSwiftSupport only supports hardcoded value if we want to set our node to a certain size, which might not be the solution in some cases such as setting full width, or half of another node’s height, etc. This PR is going to add another capability to set the width & height using `ASDimension` parameter directly so we can utilize the `ASDimension` class, for example we can use `ASDimensionWithFraction` directly to set our width/height relative to its parent, without guessing the exact value